### PR TITLE
Update grunt to 1.3.0 or higher based on dependabout alerts

### DIFF
--- a/emails/package.json
+++ b/emails/package.json
@@ -13,7 +13,7 @@
     "start": "grunt watch"
   },
   "devDependencies": {
-    "grunt": ">=1.0.1",
+    "grunt": ">=1.3.0",
     "grunt-premailer": "1.1.0",
     "grunt-processhtml": "^0.4.2",
     "grunt-uncss": "0.9.0",

--- a/emails/package.json
+++ b/emails/package.json
@@ -13,7 +13,7 @@
     "start": "grunt watch"
   },
   "devDependencies": {
-    "grunt": "1.0.1",
+    "grunt": ">=1.0.1",
     "grunt-premailer": "1.1.0",
     "grunt-processhtml": "^0.4.2",
     "grunt-uncss": "0.9.0",

--- a/emails/package.json
+++ b/emails/package.json
@@ -13,7 +13,7 @@
     "start": "grunt watch"
   },
   "devDependencies": {
-    "grunt": ">=1.3.0",
+    "grunt": "^1.3.0",
     "grunt-premailer": "1.1.0",
     "grunt-processhtml": "^0.4.2",
     "grunt-uncss": "0.9.0",


### PR DESCRIPTION
- Update grunt to 1.3.0 or higher to address depenadabout vulnerability in grunt. This is part of some email plugin which we do't use at this point