### PR TITLE
fix(deps): upgrade Go modules to resolve Dependabot security alerts (15 alerts)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -341,7 +341,7 @@ require (
 	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
-	github.com/apache/thrift v0.22.0 // indirect
+	github.com/apache/thrift v0.23.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
@@ -672,7 +672,7 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect; @grafana/identity-access-team
 	golang.org/x/mod v0.34.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c // indirect
 	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -817,6 +817,8 @@ github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apache/thrift v0.22.0 h1:r7mTJdj51TMDe6RtcmNdQxgn9XcyfGDOzegMDRg47uc=
 github.com/apache/thrift v0.22.0/go.mod h1:1e7J/O1Ae6ZQMTYdy9xa3w9k+XHWPfRvdPyJeynQ+/g=
+github.com/apache/thrift v0.23.0 h1:wKR6YnefQSEnxpEfmgTPuJibNG4bF0p2TK34tHLWi3s=
+github.com/apache/thrift v0.23.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
@@ -3186,6 +3188,8 @@ golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2/go.mod h1:TeRTkGYfJXctD9OcfyVLyj2J3IxLnKwHJR8f4D8a3YE=
 golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c h1:6a8FdnNk6bTXBjR4AGKFgUKuo+7GnR3FX5L7CbveeZc=
 golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c/go.mod h1:TpUTTEp9frx7rTdLpC9gFG9kdI7zVLFTFFlqaH2Cncw=


### PR DESCRIPTION
## Summary

Upgrades Go modules to their minimum patched versions to resolve Dependabot security alerts.

### Modules upgraded

| Module | From | To | Issue |
|--------|------|----|-------|
| github.com/apache/thrift | v0.22.0 | v0.23.0 | Integer overflow in TFramedTransport |
| golang.org/x/sys | v0.42.0 | v0.45.0 | Security fix (latest patch) |

### Modules already satisfying minimum requirements (no change needed)

| Module | Current | Required ≥ |
|--------|---------|------------|
| golang.org/x/text | v0.35.0 | v0.3.8 |
| github.com/prometheus/client_golang | v1.23.2 | v1.11.1 |
| github.com/sirupsen/logrus | v1.9.4 | v1.8.3 |
| gopkg.in/yaml.v3 | v3.0.1 | v3.0.1 |
| google.golang.org/protobuf | v1.36.11 | v1.33.0 |

### Skipped / not applicable

- **github.com/grafana/tempo** — uses a pseudoversion (v1.5.1-0.20250529124718-87c2dc380cec); no v2.x release available in the module proxy. The pseudoversion is a post-v1 commit from 2025-05-29, likely already patched.
- **github.com/gohugoio/hugo** — not present as a direct or transitive dependency in go.mod.
- **github.com/docker/docker** — no patched version available upstream (3 alerts remain open, tracked separately).

**npm vulnerabilities** are addressed in a separate PR: fix/dependabot-npm-security-upgrades.

## Test plan
- [ ] `go build ./...` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)